### PR TITLE
Missing implementation in the AbstractBeanTestCase class. 

### DIFF
--- a/src/test/java/com/parasoft/parabank/test/util/AbstractBeanTestCase.java
+++ b/src/test/java/com/parasoft/parabank/test/util/AbstractBeanTestCase.java
@@ -154,6 +154,8 @@ public abstract class AbstractBeanTestCase<T> extends AbstractParaBankTest {
             field.set(obj, on ? new Date() : new Date(0));
         } else if (field.getType().isEnum()) {
             field.set(obj, field.getType().getEnumConstants()[on ? 1 : 0]);
+        } else if (field.getType().isArray()) {
+            field.set(obj, Array.newInstance(field.getType().getComponentType(), 0));
         } else if (Object.class.isAssignableFrom(field.getType())) {
             field.set(obj, field.getType().newInstance());
         } else {


### PR DESCRIPTION
Missing implementation in the AbstractBeanTestCase class. For more detailed information please visit JT-69833.